### PR TITLE
Improve run logging and summaries

### DIFF
--- a/@classi/classi.m
+++ b/@classi/classi.m
@@ -587,6 +587,90 @@ end
         end
 
 
+        function copied = runCopyArtifacts(obj, varargin)
+            % runCopyArtifacts  Copy key classifier artifacts into the active run folder.
+            %
+            % copied = obj.runCopyArtifacts('ExtraFiles', {"/abs/path/other.mat", ...});
+
+            p = inputParser;
+            addParameter(p,'ExtraFiles',{},@(x) iscell(x) || isstring(x) || ischar(x));
+            parse(p,varargin{:});
+
+            if nargout
+                copied = strings(0,1);
+            else
+                copied = [];
+            end
+
+            if ~obj.localRunIsActive(), return; end
+
+            runDir = '';
+            try
+                runDir = obj.run.runDir;
+            catch
+                runDir = '';
+            end
+
+            if ~(ischar(runDir) || isstring(runDir)) || strlength(string(runDir))==0
+                return;
+            end
+
+            runDir = char(runDir);
+            if ~exist(runDir,'dir')
+                try
+                    mkdir(runDir);
+                catch
+                    return;
+                end
+            end
+
+            sid  = '';
+            base = '';
+            try, sid = char(string(obj.strid)); catch, sid = ''; end
+            try, base = char(string(obj.path)); catch, base = ''; end
+
+            candidates = strings(0,1);
+            if ~isempty(base)
+                if ~isempty(sid)
+                    candidates(end+1) = fullfile(base, sprintf('%s_classification.mat', sid)); %#ok<AGROW>
+                    candidates(end+1) = fullfile(base, sprintf('%s.mat', sid)); %#ok<AGROW>
+                    candidates(end+1) = fullfile(base, sprintf('netCNN_%s.mat', sid)); %#ok<AGROW>
+                    candidates(end+1) = fullfile(base, sprintf('netLSTM_%s.mat', sid)); %#ok<AGROW>
+                end
+                candidates(end+1) = fullfile(base, 'netCNN.mat'); %#ok<AGROW>
+                candidates(end+1) = fullfile(base, 'netLSTM.mat'); %#ok<AGROW>
+            end
+
+            extra = string(p.Results.ExtraFiles);
+            candidates = unique([candidates; extra(:)]);
+            candidates = candidates(strlength(candidates) > 0);
+
+            copiedLocal = strings(0,1);
+
+            for i = 1:numel(candidates)
+                src = char(candidates(i));
+                if exist(src,'file') ~= 2
+                    continue;
+                end
+
+                [~, name, ext] = fileparts(src);
+                dst = fullfile(runDir, [name ext]);
+
+                try
+                    copyfile(src, dst);
+                    copiedLocal(end+1) = string(dst); %#ok<AGROW>
+                    obj.runMsg('Copied artifact: %s', dst);
+                catch ME
+                    obj.runMsg('WARN copy artifact failed: %s (%s)', src, ME.message);
+                end
+            end
+
+            if nargout
+                copied = copiedLocal;
+            end
+        end
+
+
      function runStop(obj)
 % runStop  Stop diary and close the run.
 

--- a/@classi/trainClassifier.m
+++ b/@classi/trainClassifier.m
@@ -22,6 +22,12 @@ if nargin == 1
 
         classif.runMsg('Training finished successfully');
 
+        try
+            classif.runCopyArtifacts();
+        catch ME
+            classif.runMsg('WARN runCopyArtifacts failed: %s', ME.message);
+        end
+
     catch ME
         % --- Log error with full stack ---
         classif.runMsg('ERROR during training:');

--- a/@classi/validateTrainingData.m
+++ b/@classi/validateTrainingData.m
@@ -18,6 +18,9 @@ closeRun  = true;
 statsArgs = {};
 
 argsClassify = {};
+argsSummary  = {};
+
+summaryKeys = ["open","savecsv","runsroot","filter","sortby"];
 
 % ---------------- parse varargin ----------------
 i = 1;
@@ -29,6 +32,17 @@ while i <= numel(varargin)
         continue;
     end
     keyL = lower(strtrim(string(key)));
+
+    if any(keyL == summaryKeys)
+        if i < numel(varargin)
+            argsSummary = [argsSummary, {char(key), varargin{i+1}}]; %#ok<AGROW>
+            i = i + 2;
+        else
+            argsSummary = [argsSummary, {char(key)}]; %#ok<AGROW>
+            i = i + 1;
+        end
+        continue;
+    end
 
     if keyL == "dostats"
         if i < numel(varargin) && (islogical(varargin{i+1}) || isnumeric(varargin{i+1}))
@@ -248,6 +262,15 @@ end
 if runActive && closeRun
     runMsg('--- VALIDATION END ---');
     runStop();
+end
+
+% ---------------- summarize runs (silent update) ----------------
+try
+    summarizeRuns(classif, argsSummary{:});
+catch ME
+    if runActive
+        runMsg('summarizeRuns failed: %s', ME.getReport('basic','hyperlinks','off'));
+    end
 end
 
 end


### PR DESCRIPTION
## Summary
- add a reusable `runCopyArtifacts` helper to snapshot classification objects and trained networks into run folders
- trigger artifact copying after successful training runs
- refresh run summary spreadsheets automatically at the end of validation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cffb4b8188333921ff926c22c4f59)